### PR TITLE
Add check if there is no any Host directive or empty config file

### DIFF
--- a/nssh
+++ b/nssh
@@ -4,8 +4,15 @@ trap "clear" EXIT
 
 HOST_LIST=()
 while read -r line; do
-    HOST_LIST+=($line "")
+    if [[ -n "$line" ]] && [[ "$line" != "Host " ]]; then
+        HOST_LIST+=($line "")
+    fi
 done <<< $(grep -Poh "(?<=^Host\s)[\w._-]*$" ~/.ssh/config)
+
+if [ ${#HOST_LIST[@]} -eq 0 ]; then
+    echo "Error: No SSH hosts found in configuration file"
+    exit 1
+fi
 
 HEIGHT=20
 WIDTH=60


### PR DESCRIPTION
There was unpredictable behavior when there is no any HOST in ssh config file or .ssh/config was absent at all.
Take in mind that script clears screen history on exit - it was hard to understand what happens. 